### PR TITLE
Opt-in for automatic reboot

### DIFF
--- a/global/post-tasks.d/999reboot
+++ b/global/post-tasks.d/999reboot
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-test -f /var/run/reboot-required -a ! -f /etc/cosmos-manual-reboot && reboot
+if [ -f /var/run/reboot-required -a -f /etc/cosmos-automatic-reboot ]; then
+  reboot
+fi


### PR DESCRIPTION
Use of && is bad in this context since it will return 1 causing cosmos to exit
with status 1 if a reboot is not required.
